### PR TITLE
Add indexes to last_name and modified_timestamp (separately)

### DIFF
--- a/back-end/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/back-end/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -41,3 +41,5 @@ databaseChangeLog:
       file: db/changelog/ppldb/20200217_CANDIDATE_AC_IMAGE.xml
   - include:
       file: db/changelog/ppldb/20200303_CANDIDATE_AC.xml
+  - include:
+      file: db/changelog/ppldb/20200317_CANDIDATE_AC.xml

--- a/back-end/src/main/resources/db/changelog/ppldb/20200317_CANDIDATE_AC.xml
+++ b/back-end/src/main/resources/db/changelog/ppldb/20200317_CANDIDATE_AC.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <!-- This change set adds indices to efficiently sort the list 
+         of candidates -->
+    <changeSet author="interns" id="ppl_candidate_ac_004">
+
+        <!-- Index to order by last name -->
+        <createIndex schemaName="management" tableName="candidate"
+                indexName="candidate_last_name_index">
+            <column name="last_name" />
+        </createIndex>
+
+        <!-- Index to order by last modified
+             Had to use sql to specify ordering direction -->
+        <sql dbms="postgresql">
+            CREATE INDEX candidate_last_modified_index
+                ON management.candidate USING btree
+                (modified_timestamp DESC NULLS LAST)
+                TABLESPACE pg_default
+        </sql>
+
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added btree indexes to the columns last_name and modified_timestamp, in the table candidate, with liquibase.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The OrderBy feature in the list of candidates sorts the list by last name or modified date, this operation can overload the DBMS especially if no indexes are available for the corresponding columns on the DB and many rows exist.  When the DBMS has appropriate indexes for the corresponding columns, the process is accelerated, and fewer resources of the cloud infrastructure (AWS) are used.

<!-- ## How Has This Been Tested? -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!-- ### Do you have any tests?
- [ ] Yes
- [ ] No -->

