### PR TITLE
home test, candidate-list test and candidate-form test

### DIFF
--- a/front-end/src/app/candidate/data-candidate/data-candidate.component.spec.ts
+++ b/front-end/src/app/candidate/data-candidate/data-candidate.component.spec.ts
@@ -8,6 +8,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DatePickerModule } from '@syncfusion/ej2-angular-calendars';
+import { CandidateService } from 'src/app/service/candidate.service';
+
 
 describe('DataCandidateComponent', () => {
   let component: DataCandidateComponent;
@@ -18,7 +20,7 @@ describe('DataCandidateComponent', () => {
       imports: [FormsModule, ReactiveFormsModule, HttpClientModule, RouterTestingModule,
         BrowserAnimationsModule, ToastrModule.forRoot(), DatePickerModule ],
       declarations: [ DataCandidateComponent, HeaderComponent ],
-      providers: [ToastrService]
+      providers: [ToastrService, CandidateService]
     })
     .compileComponents();
   }));
@@ -68,6 +70,19 @@ describe('DataCandidateComponent', () => {
 
   it('Test whether the default image loads at the start of a new candidate', () => {
     expect(component.imageUrl).toContain('/assets/images/default.png');
+  });
+  it('Valid candidate service', () => {
+    component.dataCandidateForm.controls['name'].setValue('Candidato');
+    component.dataCandidateForm.controls['lastName'].setValue('Apellido');
+    fixture.detectChanges();
+    expect(component.dataCandidateForm.valid).toBeTruthy();
+    const candidateService = fixture.debugElement.injector.get(CandidateService);
+    const persistSpy = spyOn(candidateService, 'addCandidate').and.callThrough(); // create spy
+    const bt = fixture.debugElement.query(By.css('.btn-pm')).nativeElement;
+    bt.click();
+    expect(candidateService.addCandidate).toHaveBeenCalled();
+
+
   });
 
 });

--- a/front-end/src/app/candidate/list-candidate/list-candidate.component.spec.ts
+++ b/front-end/src/app/candidate/list-candidate/list-candidate.component.spec.ts
@@ -7,15 +7,21 @@ import { HttpClientModule } from '@angular/common/http';
 import { HeaderComponent } from 'src/app/shared/layout/header/header.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ToastrModule, ToastrService } from 'ngx-toastr';
+import { Router } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { DataRequest } from 'src/app/models/data-request';
+import { ResponseList } from 'src/app/models/responseList';
 
 describe('ListCandidateComponent', () => {
   let component: ListCandidateComponent;
   let fixture: ComponentFixture<ListCandidateComponent>;
+  let data: DataRequest;
+  let listR: ResponseList;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule, ReactiveFormsModule, HttpClientModule, RouterTestingModule, ToastrModule.forRoot()],
-      declarations: [ ListCandidateComponent, HeaderComponent ],
+      declarations: [ ListCandidateComponent, HeaderComponent],
       providers: [ToastrService],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })
@@ -31,5 +37,24 @@ describe('ListCandidateComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+  
+  it('call to add function', async(() => {
+    spyOn(component, 'toViewCandidateAdd');
+    const bt = fixture.debugElement.query(By.css('.btn-lg')).nativeElement;
+    bt.click();
+    expect(component.toViewCandidateAdd).toHaveBeenCalledTimes(1);
+
+  }));
+  
+  it('redirect on add candidate', () => {
+    const bt = fixture.debugElement.query(By.css('.btn-lg')).nativeElement;
+    bt.click();
+    fixture.whenStable().then(() => {
+      setTimeout(() => {fixture.detectChanges();
+      TestBed.get(Router).url;
+      expect(TestBed.get(Router).url).toBe('/candidate/data');
+    });
+  });
   });
 });

--- a/front-end/src/app/record/list-record/list-record.component.spec.ts
+++ b/front-end/src/app/record/list-record/list-record.component.spec.ts
@@ -8,6 +8,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ToastrModule, ToastrService } from 'ngx-toastr';
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 import { NgbPaginationConfig } from '@ng-bootstrap/ng-bootstrap';
+import { By } from '@angular/platform-browser';
 
 describe('ListRecordComponent', () => {
   let component: ListRecordComponent;
@@ -46,5 +47,12 @@ describe('ListRecordComponent', () => {
     fixture.detectChanges();
     console.log(component.list_records);
     expect(component.list_records).toEqual([]);
+  });
+
+  it('show detail', () => {
+    const fixture = TestBed.createComponent(ListRecordComponent);
+    fixture.detectChanges();
+   let labelName = fixture.debugElement.query(By.css('.form-control')).nativeElement;
+    expect(labelName.textContent.trim()).toBe("No items to display!");
   });
 });


### PR DESCRIPTION
## Description
In the candidate form, a test was created for the varification of the call to the save candidate service.
In the candidate list, a test was created to verify the call to the add candidate function and also another test to verify the redirect to the add form.
A list-record test to verify that it shows you a text in the case of no added candidates.

## Motivation and Context
In order to continue with the creation of tests, some tests have been created in Home, Candidate List, Candidate Form


## How Has This Been Tested?
The tests are based on waiting for a function call by means of spyOn ()
They are also based on verifying the redirection of routes using the .get(Router).url


### Do you have any tests?
- [x] Yes
- [ ] No

